### PR TITLE
Added Value method to get reflect.Value from underlying entities

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -200,7 +200,7 @@ func FromDict(m *starlark.Dict) map[interface{}]interface{} {
 		key := FromValue(k)
 		// should never be not found or unhashable, so ignore err and found.
 		val, _, _ := m.Get(k)
-		ret[key] = val
+		ret[key] = FromValue(val)
 	}
 	return ret
 }

--- a/convert/interface.go
+++ b/convert/interface.go
@@ -43,6 +43,11 @@ type GoInterface struct {
 	v reflect.Value
 }
 
+// Value returns relfect.Value of the underlying interface
+func (g *GoInterface) Value() reflect.Value {
+	return g.v
+}
+
 // Attr returns a starlark value that wraps the method or field with the given
 // name.
 func (g *GoInterface) Attr(name string) (starlark.Value, error) {

--- a/convert/map.go
+++ b/convert/map.go
@@ -32,6 +32,11 @@ func NewGoMap(m interface{}) *GoMap {
 	return &GoMap{v: v}
 }
 
+// Value returns relfect.Value of the underlying map
+func (g *GoMap) Value() reflect.Value {
+	return g.v
+}
+
 // SetKey implements starlark.HasSetKey.
 func (g *GoMap) SetKey(k, v starlark.Value) (err error) {
 	if g.frozen {

--- a/convert/slice.go
+++ b/convert/slice.go
@@ -21,7 +21,7 @@ type GoSlice struct {
 	frozen bool
 }
 
-// NewGoMap wraps the given slice in a new GoSlice.  This function will panic if m
+// NewGoSlice wraps the given slice in a new GoSlice.  This function will panic if m
 // is not a map.
 func NewGoSlice(slice interface{}) *GoSlice {
 	v := reflect.ValueOf(slice)
@@ -29,6 +29,11 @@ func NewGoSlice(slice interface{}) *GoSlice {
 		panic(fmt.Errorf("NewGoSlice expects a slice or array, but got %T", slice))
 	}
 	return &GoSlice{v: v}
+}
+
+// Value returns relfect.Value of the underlying slice
+func (g *GoSlice) Value() reflect.Value {
+	return g.v
 }
 
 // String returns the string representation of the value.

--- a/convert/struct.go
+++ b/convert/struct.go
@@ -24,6 +24,11 @@ type GoStruct struct {
 	v reflect.Value
 }
 
+// Value returns relfect.Value of the underlying struct
+func (g *GoStruct) Value() reflect.Value {
+	return g.v
+}
+
 // Attr returns a starlark value that wraps the method or field with the given
 // name.
 func (g *GoStruct) Attr(name string) (starlark.Value, error) {


### PR DESCRIPTION
This will be helpful for working with values received by Go functions added to the globals.
```go
globals := map[string: interface{}{
  "f": func Something(v inteface{}){
    //v will be *GoMap type
  },
  "v": map[string]interface{},
}
```
starlark
`f(v)`
